### PR TITLE
Fixed the styling of filtered search results. 

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -97,7 +97,7 @@ export default function Home() {
 
       <section
         ref={animationParent}
-        className="flex flex-wrap gap-3 gap-y-9 md:justify-between justify-center"
+        className="grid grid-cols-5 gap-3 gap-y-9 md:justify-between justify-center"
       >
         {isLoading &&
           Array(10)


### PR DESCRIPTION
After searching for a country, an issue arose where the filtered results were initially displayed with a significant gap between each card. To address this, I refined the styling to maintain consistent spacing between cards even when search results are presented. 